### PR TITLE
Fix TypeScript build errors

### DIFF
--- a/src/pages/events/[slug].astro
+++ b/src/pages/events/[slug].astro
@@ -6,6 +6,7 @@ import Faq from "@/components/eventpage/accordion";
 import Timeline from "@/components/eventpage/timeline";
 import { Image } from "astro:assets";
 import { partnerMap } from "@/partners"
+import type { Partner } from "@/partners";
 
 import { getCollection } from "astro:content";
 // 1. Generate a new path for every collection entry
@@ -19,9 +20,17 @@ export async function getStaticPaths() {
 // 2. For your template, you can get the entry directly from the prop
 const { entry } = Astro.props;
 
-const partners = entry.data.partners
+const partners: Partner[] | undefined = entry.data.partners
   ? partnerMap[entry.data.partners as keyof typeof partnerMap]
   : undefined;
+const groupedPartners: Record<number, Partner[]> = partners
+  ? partners.reduce<Record<number, Partner[]>>((acc, partner) => {
+      const pos = partner.position ?? 0;
+      acc[pos] = acc[pos] || [];
+      acc[pos].push(partner);
+      return acc;
+    }, {})
+  : {};
 let title = entry.data.title;
 let formattedTitle = title.replace(" ", "<br>");
 ---
@@ -83,13 +92,7 @@ let formattedTitle = title.replace(" ", "<br>");
             Proudly supported by:
           </p>
             <div class="flex flex-col gap-y-4">
-              {Object.entries(
-                partners.reduce((acc, partner) => {
-                  acc[partner.position] = acc[partner.position] || [];
-                  acc[partner.position].push(partner);
-                  return acc;
-                }, {})
-              ).map(([position, group]) => (
+              {Object.entries(groupedPartners).map(([position, group]) => (
                 <div class="flex justify-center gap-x-4">
                   {group.map((partner) => (
                     <div class="flex justify-center items-center flex-1">

--- a/src/partners.ts
+++ b/src/partners.ts
@@ -4,10 +4,19 @@ import moetext from "./img/partners/moetext.svg";
 import sutd from "./img/partners/sutd.webp";
 import okx from "./img/partners/okx.svg";
 import revenuecat from "./img/partners/revenuecat.svg";
-import yubico from "./img/partners/yubico.svg"
-import nie from "./img/partners/nie.webp"
+import yubico from "./img/partners/yubico.svg";
+import nie from "./img/partners/nie.webp";
+import type { ImageMetadata } from "astro";
 
-export const curr_partners = [
+export interface Partner {
+  src: ImageMetadata;
+  title: string;
+  desc: string;
+  website: string;
+  position?: number;
+}
+
+export const curr_partners: Partner[] = [
     {
         src: sutd,
         title: "Singapore University of Technology and Design",
@@ -59,7 +68,7 @@ export const curr_partners = [
     },
 ];
 
-export const prev_partners = [
+export const prev_partners: Partner[] = [
     {
         src: github,
         title: "GitHub",
@@ -87,7 +96,7 @@ export const prev_partners = [
     },
 ];
 
-export const partnerMap = {
-    curr_partners,
-    prev_partners,
+export const partnerMap: Record<"curr_partners" | "prev_partners", Partner[]> = {
+  curr_partners,
+  prev_partners,
 };


### PR DESCRIPTION
## Summary
- define a `Partner` interface and type exported partner lists
- group partners in frontmatter and use typed `groupedPartners`

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6847968862fc8328af4049fb481373d7